### PR TITLE
COMP: Add CMake 4 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.20.6...3.22.6 FATAL_ERROR)
 
 project(DeveloperToolsForExtensions)
 


### PR DESCRIPTION
CMake 4 dropped support for cmake_minimum_required specifying a version < 3.5. This updates the minimum required version to match latest Slicer stable (5.10.0) https://github.com/Slicer/Slicer/blob/a2b6d082be04274a849884fbb1e85634a9df90fb/CMakeLists.txt#L1